### PR TITLE
Async flushes

### DIFF
--- a/cmd/substreams-sink-sql/common_flags.go
+++ b/cmd/substreams-sink-sql/common_flags.go
@@ -60,12 +60,13 @@ func newDBLoader(
 	batchBlockFlushInterval int,
 	batchRowFlushInterval int,
 	liveBlockFlushInterval int,
+	maxParallelFlushes int,
 	handleReorgs bool,
 ) (*db.Loader, error) {
 	moduleMismatchMode, err := db.ParseOnModuleHashMismatch(sflags.MustGetString(cmd, onModuleHashMistmatchFlag))
 	cli.NoError(err, "invalid mistmatch mode")
 
-	dbLoader, err := db.NewLoader(psqlDSN, batchBlockFlushInterval, batchRowFlushInterval, liveBlockFlushInterval, moduleMismatchMode, &handleReorgs, zlog, tracer)
+	dbLoader, err := db.NewLoader(psqlDSN, batchBlockFlushInterval, batchRowFlushInterval, liveBlockFlushInterval, maxParallelFlushes, moduleMismatchMode, &handleReorgs, zlog, tracer)
 	if err != nil {
 		return nil, fmt.Errorf("new psql loader: %w", err)
 	}
@@ -94,7 +95,7 @@ func AddCommonSinkerFlags(flags *pflag.FlagSet) {
 		- If 'warn' is used, it does the same as 'ignore' but it will log a warning message when it happens.
 		- If 'ignore' is set, we pick the cursor at the highest block number and use it as the starting point. Subsequent
 		updates to the cursor will overwrite the module hash in the database.
-	`))
+	    `))
 }
 
 func readBlockRangeArgument(in string) (blockRange *bstream.Range, err error) {

--- a/cmd/substreams-sink-sql/create_user.go
+++ b/cmd/substreams-sink-sql/create_user.go
@@ -45,7 +45,7 @@ func createUserE(cmd *cobra.Command, args []string) error {
 	}
 
 	if err := retry(ctx, func(ctx context.Context) error {
-		dbLoader, err := db.NewLoader(dsn, 0, 0, 0, db.OnModuleHashMismatchError, nil, zlog, tracer)
+		dbLoader, err := db.NewLoader(dsn, 0, 0, 0, 1, db.OnModuleHashMismatchError, nil, zlog, tracer)
 		if err != nil {
 			return fmt.Errorf("new psql loader: %w", err)
 		}

--- a/cmd/substreams-sink-sql/generate_csv.go
+++ b/cmd/substreams-sink-sql/generate_csv.go
@@ -107,7 +107,15 @@ func generateCsvE(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("new base sinker: %w", err)
 	}
 
-	dbLoader, err := newDBLoader(cmd, dsn, 0, 0, 0, false) // flush interval not used in CSV mode
+	dbLoader, err := newDBLoader(
+		cmd,
+		dsn,
+		0,
+		0,
+		0,
+		1,
+		false,
+	)
 	if err != nil {
 		return fmt.Errorf("new db loader: %w", err)
 	}

--- a/cmd/substreams-sink-sql/run.go
+++ b/cmd/substreams-sink-sql/run.go
@@ -32,7 +32,7 @@ var sinkRunCmd = Command(sinkRunE,
 		flags.Int("batch-row-flush-interval", 100_000, "When in catch up mode, flush every N rows or after batch-block-flush-interval, whichever comes first. Set to 0 to disable and only use batch-block-flush-interval. Ineffective if the sink is now in the live portion of the chain where only 'live-block-flush-interval' applies.")
 		flags.Int("live-block-flush-interval", 1, "When processing in live mode, flush every N blocks.")
 		flags.Int("flush-interval", 0, "(deprecated) please use --batch-block-flush-interval instead")
-		flags.Int("max-parallel-flushes", 3, "Maximum number of parallel async flushes when running 'run'. Minimum is 1.")
+		flags.Int("max-parallel-flushes", 1, "Maximum number of parallel async flushes. Minimum is 1.")
 		flags.String("idle-timeout", "", "Duration to wait without data messages before triggering a reconnect, e.g. '10m', '1h'. Waiting for first block doesn't count as idle.")
 		flags.StringP("endpoint", "e", "", "Specify the substreams endpoint, ex: `mainnet.eth.streamingfast.io:443`")
 	}),

--- a/cmd/substreams-sink-sql/run.go
+++ b/cmd/substreams-sink-sql/run.go
@@ -32,6 +32,7 @@ var sinkRunCmd = Command(sinkRunE,
 		flags.Int("batch-row-flush-interval", 100_000, "When in catch up mode, flush every N rows or after batch-block-flush-interval, whichever comes first. Set to 0 to disable and only use batch-block-flush-interval. Ineffective if the sink is now in the live portion of the chain where only 'live-block-flush-interval' applies.")
 		flags.Int("live-block-flush-interval", 1, "When processing in live mode, flush every N blocks.")
 		flags.Int("flush-interval", 0, "(deprecated) please use --batch-block-flush-interval instead")
+		flags.Int("max-parallel-flushes", 3, "Maximum number of parallel async flushes when running 'run'. Minimum is 1.")
 		flags.String("idle-timeout", "", "Duration to wait without data messages before triggering a reconnect, e.g. '10m', '1h'. Waiting for first block doesn't count as idle.")
 		flags.StringP("endpoint", "e", "", "Specify the substreams endpoint, ex: `mainnet.eth.streamingfast.io:443`")
 	}),
@@ -105,7 +106,15 @@ func sinkRunE(cmd *cobra.Command, args []string) error {
 		batchBlockFlushInterval = sflags.MustGetInt(cmd, "flush-interval")
 	}
 
-	dbLoader, err := newDBLoader(cmd, dsn, batchBlockFlushInterval, sflags.MustGetInt(cmd, "batch-row-flush-interval"), sflags.MustGetInt(cmd, "live-block-flush-interval"), handleReorgs)
+	dbLoader, err := newDBLoader(
+		cmd,
+		dsn,
+		batchBlockFlushInterval,
+		sflags.MustGetInt(cmd, "batch-row-flush-interval"),
+		sflags.MustGetInt(cmd, "live-block-flush-interval"),
+		sflags.MustGetInt(cmd, "max-parallel-flushes"),
+		handleReorgs,
+	)
 	if err != nil {
 		return fmt.Errorf("new db loader: %w", err)
 	}

--- a/cmd/substreams-sink-sql/setup.go
+++ b/cmd/substreams-sink-sql/setup.go
@@ -46,7 +46,7 @@ func sinkSetupE(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("extract sink config: %w", err)
 	}
 
-	dbLoader, err := db.NewLoader(dsn, 0, 0, 0, db.OnModuleHashMismatchError, nil, zlog, tracer)
+	dbLoader, err := db.NewLoader(dsn, 0, 0, 0, 1, db.OnModuleHashMismatchError, nil, zlog, tracer)
 	if err != nil {
 		return fmt.Errorf("new psql loader: %w", err)
 	}

--- a/cmd/substreams-sink-sql/tools.go
+++ b/cmd/substreams-sink-sql/tools.go
@@ -145,7 +145,7 @@ func toolsDeleteCursorE(cmd *cobra.Command, args []string) error {
 
 func toolsCreateLoader() *db.Loader {
 	dsn := viper.GetString("tools-global-dsn")
-	loader, err := db.NewLoader(dsn, 0, 0, 0, db.OnModuleHashMismatchIgnore, nil, zlog, tracer)
+	loader, err := db.NewLoader(dsn, 0, 0, 0, 1, db.OnModuleHashMismatchIgnore, nil, zlog, tracer)
 	cli.NoError(err, "Unable to instantiate database manager from DSN %q", dsn)
 
 	if err := loader.LoadTables(); err != nil {

--- a/db/db.go
+++ b/db/db.go
@@ -205,8 +205,10 @@ func (l *Loader) WaitForAllFlushes() {
 
 // FlushAsync triggers a non-blocking flush. Blocks if the maximum number of parallel flushes is reached until a flush is completed.
 func (l *Loader) FlushAsync(ctx context.Context, outputModuleHash string, cursor *sink.Cursor, lastFinalBlock uint64) bool {
+	l.logger.Info("async flush: starting flush", zap.Int("active_flushes", l.activeFlushes), zap.Uint64("last_final_block", lastFinalBlock))
 	l.mu.Lock()
 	for l.activeFlushes >= l.maxParallelFlushes {
+		l.logger.Info("async flush: maximum number of parallel flushes reached, waiting for a flush to complete")
 		l.cond.Wait()
 	}
 	// Snapshot entries and replace with a fresh buffer

--- a/db/db.go
+++ b/db/db.go
@@ -248,6 +248,11 @@ func (l *Loader) FlushAsync(ctx context.Context, outputModuleHash string, cursor
 		tl := *l
 		tl.entries = snapshot
 
+		// Disallow cancellation of the context to prevent holes in the data with parallel flushes
+		if l.maxParallelFlushes > 1 {
+			ctx = context.WithoutCancel(ctx)
+		}
+
 		// Perform a single flush attempt with its own transaction (reusing existing logic but avoiding reset())
 		tx, err := l.BeginTx(ctx, nil)
 		if err != nil {

--- a/db/db.go
+++ b/db/db.go
@@ -221,10 +221,10 @@ func (l *Loader) WaitForAllFlushes() {
 
 // FlushAsync triggers a non-blocking flush. Blocks if the maximum number of parallel flushes is reached until a flush is completed.
 func (l *Loader) FlushAsync(ctx context.Context, outputModuleHash string, cursor *sink.Cursor, lastFinalBlock uint64) bool {
-	l.logger.Info("async flush: starting flush", zap.Int("active_flushes", l.activeFlushes), zap.Uint64("last_final_block", lastFinalBlock))
+	l.logger.Debug("async flush: starting flush", zap.Int("active_flushes", l.activeFlushes), zap.Uint64("last_final_block", lastFinalBlock))
 	l.mu.Lock()
 	for l.activeFlushes >= l.maxParallelFlushes {
-		l.logger.Info("async flush: maximum number of parallel flushes reached, waiting for a flush to complete")
+		l.logger.Debug("async flush: maximum number of parallel flushes reached, waiting for a flush to complete")
 		l.cond.Wait()
 	}
 	// Snapshot entries and replace with a fresh buffer
@@ -233,7 +233,7 @@ func (l *Loader) FlushAsync(ctx context.Context, outputModuleHash string, cursor
 	l.activeFlushes++
 	l.mu.Unlock()
 
-	l.logger.Info("async flush started", zap.Int("active_flushes", l.activeFlushes-1))
+	l.logger.Debug("async flush started", zap.Int("active_flushes", l.activeFlushes-1))
 
 	go func() {
 		// cleanup defer
@@ -284,7 +284,7 @@ func (l *Loader) FlushAsync(ctx context.Context, outputModuleHash string, cursor
 		committed = true
 
 		took := time.Since(start)
-		l.logger.Info("async flush complete",
+		l.logger.Debug("async flush complete",
 			zap.Int("row_count", rowFlushedCount),
 			zap.Duration("took", took))
 

--- a/db/flush.go
+++ b/db/flush.go
@@ -22,6 +22,9 @@ func (l *Loader) Flush(ctx context.Context, outputModuleHash string, cursor *sin
 				zap.Int("row_count", rowFlushedCount),
 				zap.Duration("took", time.Since(startAt)),
 			)
+			if l.onFlush != nil {
+				l.onFlush(rowFlushedCount, time.Since(startAt))
+			}
 			return rowFlushedCount, nil
 		}
 		l.logger.Warn("Flush attempt failed",

--- a/db/operations_test.go
+++ b/db/operations_test.go
@@ -68,7 +68,7 @@ func TestEscapeValues(t *testing.T) {
 		t.Skip(`PG_DSN not set, please specify PG_DSN to run this test, example: PG_DSN="psql://dev-node:insecure-change-me-in-prod@localhost:5432/dev-node?enable_incremental_sort=off&sslmode=disable"`)
 	}
 
-	dbLoader, err := NewLoader(dsn, 0, 0, 0, OnModuleHashMismatchIgnore, nil, zlog, tracer)
+	dbLoader, err := NewLoader(dsn, 0, 0, 0, 1, OnModuleHashMismatchIgnore, nil, zlog, tracer)
 	require.NoError(t, err)
 
 	tx, err := dbLoader.DB.Begin()

--- a/db/operations_test.go
+++ b/db/operations_test.go
@@ -19,7 +19,7 @@ func TestEscapeColumns(t *testing.T) {
 		t.Skip(`PG_DSN not set, please specify PG_DSN to run this test, example: PG_DSN="psql://dev-node:insecure-change-me-in-prod@localhost:5432/dev-node?enable_incremental_sort=off&sslmode=disable"`)
 	}
 
-	dbLoader, err := NewLoader(dsn, 0, 0, 0, OnModuleHashMismatchIgnore, nil, zlog, tracer)
+	dbLoader, err := NewLoader(dsn, 0, 0, 0, 1, OnModuleHashMismatchIgnore, nil, zlog, tracer)
 	require.NoError(t, err)
 
 	tx, err := dbLoader.DB.Begin()

--- a/db/ops.go
+++ b/db/ops.go
@@ -13,8 +13,8 @@ import (
 func (l *Loader) Insert(tableName string, primaryKey map[string]string, data map[string]string, reversibleBlockNum *uint64) error {
 	uniqueID := createRowUniqueID(primaryKey)
 
-	l.mu.Lock()
-	defer l.mu.Unlock()
+	l.cond.L.Lock()
+	defer l.cond.L.Unlock()
 
 	if l.tracer.Enabled() {
 		l.logger.Debug("processing insert operation", zap.String("table_name", tableName), zap.String("primary_key", uniqueID), zap.Int("field_count", len(data)))
@@ -93,8 +93,8 @@ func (l *Loader) Update(tableName string, primaryKey map[string]string, data map
 		l.logger.Debug("processing update operation", zap.String("table_name", tableName), zap.String("primary_key", uniqueID), zap.Int("field_count", len(data)))
 	}
 
-	l.mu.Lock()
-	defer l.mu.Unlock()
+	l.cond.L.Lock()
+	defer l.cond.L.Unlock()
 
 	table, found := l.tables[tableName]
 	if !found {
@@ -147,8 +147,8 @@ func (l *Loader) Delete(tableName string, primaryKey map[string]string, reversib
 		l.logger.Debug("processing delete operation", zap.String("table_name", tableName), zap.String("primary_key", uniqueID))
 	}
 
-	l.mu.Lock()
-	defer l.mu.Unlock()
+	l.cond.L.Lock()
+	defer l.cond.L.Unlock()
 
 	table, found := l.tables[tableName]
 	if !found {

--- a/db/testing.go
+++ b/db/testing.go
@@ -15,7 +15,7 @@ func NewTestLoader(
 	tables map[string]*TableInfo,
 ) (*Loader, *TestTx) {
 
-	loader, err := NewLoader("psql://x:5432/x", 0, 0, 0, OnModuleHashMismatchIgnore, nil, zlog, tracer)
+	loader, err := NewLoader("psql://x:5432/x", 0, 0, 0, 1, OnModuleHashMismatchIgnore, nil, zlog, tracer)
 	if err != nil {
 		panic(err)
 	}

--- a/sinker/metrics.go
+++ b/sinker/metrics.go
@@ -14,5 +14,11 @@ var FlushCount = metrics.NewCounter("substreams_sink_postgres_store_flush_count"
 var FlushedRowsCount = metrics.NewCounter("substreams_sink_postgres_flushed_rows_count", "The number of flushed rows so far")
 var FlushDuration = metrics.NewCounter("substreams_sink_postgres_store_flush_duration", "The amount of time spent flushing cache to db (in nanoseconds)")
 
+// Performance profiling metrics
+var ProtobufDecodeDuration = metrics.NewCounter("substreams_sink_postgres_proto_decode_duration", "Time spent decoding protobuf messages (in nanoseconds)")
+var ProtobufMessageSize = metrics.NewCounter("substreams_sink_postgres_proto_message_size", "Size of protobuf messages in bytes")
+var DatabaseChangesDuration = metrics.NewCounter("substreams_sink_postgres_db_changes_duration", "Time spent applying database changes (in nanoseconds)")
+var DatabaseChangesCount = metrics.NewCounter("substreams_sink_postgres_db_changes_count", "Number of database changes processed")
+
 var HeadBlockNumber = metrics.NewHeadBlockNumber("substreams_sink_postgres")
 var HeadBlockTimeDrift = metrics.NewHeadTimeDrift("substreams_sink_postgres")

--- a/sinker/sinker.go
+++ b/sinker/sinker.go
@@ -163,6 +163,8 @@ func (s *SQLSinker) HandleBlockScopedData(ctx context.Context, data *pbsubstream
 		)
 
 		s.loader.FlushAsync(ctx, s.OutputModuleHash(), cursor, data.FinalBlockHeight)
+		// Update lastAppliedBlockNum after triggering async flush
+		s.lastAppliedBlockNum = &data.Clock.Number
 	}
 
 	return nil

--- a/sinker/sinker.go
+++ b/sinker/sinker.go
@@ -52,6 +52,11 @@ func New(sink *sink.Sinker, loader *db.Loader, logger *zap.Logger, tracer loggin
 		s.stats.RecordFlushDuration(dur)
 	})
 
+	// Register an error observer so any async flush failure shuts down the sinker
+	loader.SetOnFlushError(func(err error) {
+		s.Shutdown(fmt.Errorf("async flush failed: %w", err))
+	})
+
 	return s, nil
 }
 

--- a/sinker/sinker_test.go
+++ b/sinker/sinker_test.go
@@ -220,6 +220,8 @@ func TestInserts(t *testing.T) {
 
 			for _, evt := range test.events {
 				if evt.undoSignal {
+					// Ensure previously triggered async flushes are completed before revert
+					l.WaitForAllFlushes()
 					cursor := simpleCursor(evt.blockNum, evt.libNum)
 					err := sinker.HandleBlockUndoSignal(ctx, &pbsubstreamsrpc.BlockUndoSignal{
 						LastValidBlock:  &pbsubstreams.BlockRef{Id: fmt.Sprintf("%d", evt.blockNum), Number: evt.blockNum},
@@ -236,6 +238,9 @@ func TestInserts(t *testing.T) {
 				)
 				require.NoError(t, err)
 			}
+
+			// Ensure any asynchronous flushes have completed before asserting results
+			l.WaitForAllFlushes()
 
 			results := tx.Results()
 			assert.Equal(t, test.expectSQL, results)


### PR DESCRIPTION
Based on performance investigation, even without heavy JOINs most of the time is spent on clickhouse inserts.

This PR makes flushes async (bounded by `max-parallel-flushes`) to parallelize inserts.

Once the sink is ready to flush instead of flushing the rows synchronously it starts async flush and continues to accumulate rows.

When `max-parallel-flushes` is reached it waits for one of the ongoing flushes to complete before starting a new one.

When  the sink needs to exit it awaits all flushes to complete.

Based on early testing, these changes allow to increase sink throughput from ~10K rows/s to ~20K rows/s. 

Interface changes:
- add `max-parallel-flushes` cli flag (default = 1 is enough for most cases) 
- add `substreams_sink_postgres_db_changes_duration`, `substreams_sink_postgres_proto_decode_duration` metrics to track protobuf decoding and db changes management

Caveat: if `max-parallel-flushes` > 1 we don't allow flush cancellation (i.e. via SIG_TERM) any longer because it could lead to holes in data. Instead we wait for the flushes to finish.