### PR TITLE
Improve metrics

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -453,6 +453,10 @@ func (l *Loader) HasTable(tableName string) bool {
 	return false
 }
 
+// GetActiveFlushesNum returns the current number of in-flight async flushes.
+// This value is approximate and may be racy; it is intended for metrics only.
+func (l *Loader) GetActiveFlushesNum() int { return l.activeFlushes }
+
 func (l *Loader) MarshalLogObject(encoder zapcore.ObjectEncoder) error {
 	encoder.AddUint64("entries_count", l.entriesCount)
 	return nil

--- a/sinker/metrics.go
+++ b/sinker/metrics.go
@@ -22,3 +22,5 @@ var DatabaseChangesCount = metrics.NewCounter("substreams_sink_postgres_db_chang
 
 var HeadBlockNumber = metrics.NewHeadBlockNumber("substreams_sink_postgres")
 var HeadBlockTimeDrift = metrics.NewHeadTimeDrift("substreams_sink_postgres")
+
+var ActiveFlushes = metrics.NewGauge("substreams_sink_postgres_active_flushes", "Current number of active async flushes")

--- a/sinker/sinker.go
+++ b/sinker/sinker.go
@@ -165,6 +165,7 @@ func (s *SQLSinker) HandleBlockScopedData(ctx context.Context, data *pbsubstream
 		s.loader.FlushAsync(ctx, s.OutputModuleHash(), cursor, data.FinalBlockHeight)
 
 		s.lastAppliedBlockNum = &data.Clock.Number
+		ActiveFlushes.SetUint64(uint64(s.loader.GetActiveFlushesNum()))
 		HeadBlockTimeDrift.SetBlockTime(data.Clock.GetTimestamp().AsTime())
 		HeadBlockNumber.SetUint64(data.Clock.GetNumber())
 	}

--- a/sinker/sinker.go
+++ b/sinker/sinker.go
@@ -163,8 +163,10 @@ func (s *SQLSinker) HandleBlockScopedData(ctx context.Context, data *pbsubstream
 		)
 
 		s.loader.FlushAsync(ctx, s.OutputModuleHash(), cursor, data.FinalBlockHeight)
-		// Update lastAppliedBlockNum after triggering async flush
+
 		s.lastAppliedBlockNum = &data.Clock.Number
+		HeadBlockTimeDrift.SetBlockTime(data.Clock.GetTimestamp().AsTime())
+		HeadBlockNumber.SetUint64(data.Clock.GetNumber())
 	}
 
 	return nil


### PR DESCRIPTION
- fix drift
- add `substreams_sink_postgres_active_flushes` to track active flushes