### PR TITLE
Revert async flushes

### DIFF
--- a/cmd/substreams-sink-sql/common_flags.go
+++ b/cmd/substreams-sink-sql/common_flags.go
@@ -60,13 +60,12 @@ func newDBLoader(
 	batchBlockFlushInterval int,
 	batchRowFlushInterval int,
 	liveBlockFlushInterval int,
-	maxParallelFlushes int,
 	handleReorgs bool,
 ) (*db.Loader, error) {
 	moduleMismatchMode, err := db.ParseOnModuleHashMismatch(sflags.MustGetString(cmd, onModuleHashMistmatchFlag))
 	cli.NoError(err, "invalid mistmatch mode")
 
-	dbLoader, err := db.NewLoader(psqlDSN, batchBlockFlushInterval, batchRowFlushInterval, liveBlockFlushInterval, maxParallelFlushes, moduleMismatchMode, &handleReorgs, zlog, tracer)
+	dbLoader, err := db.NewLoader(psqlDSN, batchBlockFlushInterval, batchRowFlushInterval, liveBlockFlushInterval, moduleMismatchMode, &handleReorgs, zlog, tracer)
 	if err != nil {
 		return nil, fmt.Errorf("new psql loader: %w", err)
 	}
@@ -95,7 +94,7 @@ func AddCommonSinkerFlags(flags *pflag.FlagSet) {
 		- If 'warn' is used, it does the same as 'ignore' but it will log a warning message when it happens.
 		- If 'ignore' is set, we pick the cursor at the highest block number and use it as the starting point. Subsequent
 		updates to the cursor will overwrite the module hash in the database.
-	    `))
+	`))
 }
 
 func readBlockRangeArgument(in string) (blockRange *bstream.Range, err error) {

--- a/cmd/substreams-sink-sql/create_user.go
+++ b/cmd/substreams-sink-sql/create_user.go
@@ -45,7 +45,7 @@ func createUserE(cmd *cobra.Command, args []string) error {
 	}
 
 	if err := retry(ctx, func(ctx context.Context) error {
-		dbLoader, err := db.NewLoader(dsn, 0, 0, 0, 1, db.OnModuleHashMismatchError, nil, zlog, tracer)
+		dbLoader, err := db.NewLoader(dsn, 0, 0, 0, db.OnModuleHashMismatchError, nil, zlog, tracer)
 		if err != nil {
 			return fmt.Errorf("new psql loader: %w", err)
 		}

--- a/cmd/substreams-sink-sql/generate_csv.go
+++ b/cmd/substreams-sink-sql/generate_csv.go
@@ -107,15 +107,7 @@ func generateCsvE(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("new base sinker: %w", err)
 	}
 
-	dbLoader, err := newDBLoader(
-		cmd,
-		dsn,
-		0,
-		0,
-		0,
-		1,
-		false,
-	)
+	dbLoader, err := newDBLoader(cmd, dsn, 0, 0, 0, false) // flush interval not used in CSV mode
 	if err != nil {
 		return fmt.Errorf("new db loader: %w", err)
 	}

--- a/cmd/substreams-sink-sql/run.go
+++ b/cmd/substreams-sink-sql/run.go
@@ -32,7 +32,6 @@ var sinkRunCmd = Command(sinkRunE,
 		flags.Int("batch-row-flush-interval", 100_000, "When in catch up mode, flush every N rows or after batch-block-flush-interval, whichever comes first. Set to 0 to disable and only use batch-block-flush-interval. Ineffective if the sink is now in the live portion of the chain where only 'live-block-flush-interval' applies.")
 		flags.Int("live-block-flush-interval", 1, "When processing in live mode, flush every N blocks.")
 		flags.Int("flush-interval", 0, "(deprecated) please use --batch-block-flush-interval instead")
-		flags.Int("max-parallel-flushes", 1, "Maximum number of parallel async flushes. Minimum is 1.")
 		flags.String("idle-timeout", "", "Duration to wait without data messages before triggering a reconnect, e.g. '10m', '1h'. Waiting for first block doesn't count as idle.")
 		flags.StringP("endpoint", "e", "", "Specify the substreams endpoint, ex: `mainnet.eth.streamingfast.io:443`")
 	}),
@@ -106,15 +105,7 @@ func sinkRunE(cmd *cobra.Command, args []string) error {
 		batchBlockFlushInterval = sflags.MustGetInt(cmd, "flush-interval")
 	}
 
-	dbLoader, err := newDBLoader(
-		cmd,
-		dsn,
-		batchBlockFlushInterval,
-		sflags.MustGetInt(cmd, "batch-row-flush-interval"),
-		sflags.MustGetInt(cmd, "live-block-flush-interval"),
-		sflags.MustGetInt(cmd, "max-parallel-flushes"),
-		handleReorgs,
-	)
+	dbLoader, err := newDBLoader(cmd, dsn, batchBlockFlushInterval, sflags.MustGetInt(cmd, "batch-row-flush-interval"), sflags.MustGetInt(cmd, "live-block-flush-interval"), handleReorgs)
 	if err != nil {
 		return fmt.Errorf("new db loader: %w", err)
 	}

--- a/cmd/substreams-sink-sql/setup.go
+++ b/cmd/substreams-sink-sql/setup.go
@@ -46,7 +46,7 @@ func sinkSetupE(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("extract sink config: %w", err)
 	}
 
-	dbLoader, err := db.NewLoader(dsn, 0, 0, 0, 1, db.OnModuleHashMismatchError, nil, zlog, tracer)
+	dbLoader, err := db.NewLoader(dsn, 0, 0, 0, db.OnModuleHashMismatchError, nil, zlog, tracer)
 	if err != nil {
 		return fmt.Errorf("new psql loader: %w", err)
 	}

--- a/cmd/substreams-sink-sql/tools.go
+++ b/cmd/substreams-sink-sql/tools.go
@@ -145,7 +145,7 @@ func toolsDeleteCursorE(cmd *cobra.Command, args []string) error {
 
 func toolsCreateLoader() *db.Loader {
 	dsn := viper.GetString("tools-global-dsn")
-	loader, err := db.NewLoader(dsn, 0, 0, 0, 1, db.OnModuleHashMismatchIgnore, nil, zlog, tracer)
+	loader, err := db.NewLoader(dsn, 0, 0, 0, db.OnModuleHashMismatchIgnore, nil, zlog, tracer)
 	cli.NoError(err, "Unable to instantiate database manager from DSN %q", dsn)
 
 	if err := loader.LoadTables(); err != nil {

--- a/db/db.go
+++ b/db/db.go
@@ -453,10 +453,6 @@ func (l *Loader) HasTable(tableName string) bool {
 	return false
 }
 
-// GetActiveFlushesNum returns the current number of in-flight async flushes.
-// This value is approximate and may be racy; it is intended for metrics only.
-func (l *Loader) GetActiveFlushesNum() int { return l.activeFlushes }
-
 func (l *Loader) MarshalLogObject(encoder zapcore.ObjectEncoder) error {
 	encoder.AddUint64("entries_count", l.entriesCount)
 	return nil

--- a/db/db.go
+++ b/db/db.go
@@ -4,14 +4,10 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"strings"
 	"time"
-
-	"sync"
 
 	"github.com/jimsmart/schema"
 	"github.com/streamingfast/logging"
-	sink "github.com/streamingfast/substreams-sink"
 	orderedmap "github.com/wk8/go-ordered-map/v2"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
@@ -24,43 +20,6 @@ var CLICKHOUSE_CLUSTER = ""
 // Make the typing a bit easier
 type OrderedMap[K comparable, V any] struct {
 	*orderedmap.OrderedMap[K, V]
-}
-
-// newFlushLoader creates a minimal Loader used exclusively to perform a flush
-// using the provided entries snapshot. It intentionally does not copy
-// synchronization primitives.
-func (l *Loader) newFlushLoader(snapshot *OrderedMap[string, *OrderedMap[string, *Operation]]) *Loader {
-	return &Loader{
-		DB:                       l.DB,
-		database:                 l.database,
-		schema:                   l.schema,
-		entries:                  snapshot,
-		entriesCount:             l.entriesCount,
-		tables:                   l.tables,
-		cursorTable:              l.cursorTable,
-		handleReorgs:             l.handleReorgs,
-		batchBlockFlushInterval:  l.batchBlockFlushInterval,
-		batchRowFlushInterval:    l.batchRowFlushInterval,
-		liveBlockFlushInterval:   l.liveBlockFlushInterval,
-		moduleMismatchMode:       l.moduleMismatchMode,
-		maxFlushRetries:          l.maxFlushRetries,
-		sleepBetweenFlushRetries: l.sleepBetweenFlushRetries,
-		logger:                   l.logger,
-		tracer:                   l.tracer,
-		testTx:                   l.testTx,
-	}
-}
-
-// SetOnFlush sets an optional observer invoked on successful flush completion.
-// The callback receives the number of rows flushed and the flush duration.
-func (l *Loader) SetOnFlush(cb func(rows int, dur time.Duration)) {
-	l.onFlush = cb
-}
-
-// SetOnFlushError sets an optional observer invoked when an async flush fails.
-// This enables the caller to handle shutdown or retries.
-func (l *Loader) SetOnFlushError(cb func(err error)) {
-	l.onFlushError = cb
 }
 
 func NewOrderedMap[K comparable, V any]() *OrderedMap[K, V] {
@@ -93,19 +52,6 @@ type Loader struct {
 	tracer logging.Tracer
 
 	testTx *TestTx // used for testing: if non-nil, 'loader.BeginTx()' will return this object instead of a real *sql.Tx
-
-	// async flush
-	cond               *sync.Cond
-	activeFlushes      int
-	maxParallelFlushes int
-
-	// onFlush is an optional observer called when a flush completes successfully.
-	// It receives the number of rows flushed and the total duration of the flush.
-	onFlush func(rows int, dur time.Duration)
-
-	// onFlushError is an optional observer invoked when an async flush fails.
-	// If set, it should trigger appropriate shutdown from the caller side.
-	onFlushError func(err error)
 }
 
 func NewLoader(
@@ -113,7 +59,6 @@ func NewLoader(
 	batchBlockFlushInterval int,
 	batchRowFlushInterval int,
 	liveBlockFlushInterval int,
-	maxParallelFlushes int,
 	moduleMismatchMode OnModuleHashMismatch,
 	handleReorgs *bool,
 	logger *zap.Logger,
@@ -127,10 +72,6 @@ func NewLoader(
 	db, err := sql.Open(dsn.driver, dsn.ConnString())
 	if err != nil {
 		return nil, fmt.Errorf("open db connection: %w", err)
-	}
-
-	if maxParallelFlushes < 1 {
-		maxParallelFlushes = 1
 	}
 
 	l := &Loader{
@@ -147,9 +88,7 @@ func NewLoader(
 		moduleMismatchMode:       moduleMismatchMode,
 		logger:                   logger,
 		tracer:                   tracer,
-		maxParallelFlushes:       maxParallelFlushes,
 	}
-	l.cond = sync.NewCond(&sync.Mutex{})
 	_, err = l.tryDialect()
 	if err != nil {
 		return nil, fmt.Errorf("dialect not found: %s", err)
@@ -170,7 +109,6 @@ func NewLoader(
 		zap.Int("batch_block_flush_interval", batchBlockFlushInterval),
 		zap.Int("batch_row_flush_interval", batchRowFlushInterval),
 		zap.Int("live_block_flush_interval", liveBlockFlushInterval),
-		zap.Int("max_parallel_flushes", maxParallelFlushes),
 		zap.String("driver", dsn.driver),
 		zap.String("database", dsn.database),
 		zap.String("schema", dsn.schema),
@@ -212,100 +150,13 @@ func (l *Loader) LiveBlockFlushInterval() int {
 	return l.liveBlockFlushInterval
 }
 
-func (l *Loader) GetPrimaryKey(tableName string, pk string) (map[string]string, error) {
-	table, found := l.tables[tableName]
-	if !found {
-		return nil, fmt.Errorf("unknown table %q", tableName)
-	}
-	if len(table.primaryColumns) == 1 {
-		return map[string]string{table.primaryColumns[0].name: pk}, nil
-	}
-	parts := strings.Split(pk, "/")
-	if len(parts) != len(table.primaryColumns) {
-		return nil, fmt.Errorf("composite primary key value count mismatch for table %q: got %d parts, expected %d", tableName, len(parts), len(table.primaryColumns))
-	}
-	res := make(map[string]string, len(parts))
-	for i, col := range table.primaryColumns {
-		res[col.name] = parts[i]
-	}
-	return res, nil
-}
-
 func (l *Loader) FlushNeeded() bool {
-	l.cond.L.Lock()
-	defer l.cond.L.Unlock()
 	totalRows := 0
 	// todo keep a running count when inserting/deleting rows directly
 	for pair := l.entries.Oldest(); pair != nil; pair = pair.Next() {
 		totalRows += pair.Value.Len()
 	}
 	return totalRows > l.batchRowFlushInterval
-}
-
-// WaitForAllFlushes blocks until there are no in-flight async flushes.
-func (l *Loader) WaitForAllFlushes() {
-	l.cond.L.Lock()
-	defer l.cond.L.Unlock()
-
-	for l.activeFlushes > 0 {
-		l.cond.Wait()
-	}
-}
-
-// FlushAsync triggers a non-blocking flush. Blocks if the maximum number of parallel flushes is reached until a flush is completed.
-func (l *Loader) FlushAsync(ctx context.Context, outputModuleHash string, cursor *sink.Cursor, lastFinalBlock uint64) {
-	l.logger.Debug("async flush: starting flush", zap.Int("active_flushes", l.activeFlushes), zap.Uint64("last_final_block", lastFinalBlock))
-	l.cond.L.Lock()
-	for l.activeFlushes >= l.maxParallelFlushes {
-		l.logger.Debug("async flush: maximum number of parallel flushes reached, waiting for a flush to complete")
-		l.cond.Wait()
-	}
-	// Snapshot entries and replace with a fresh buffer
-	snapshot := l.entries
-	l.entries = NewOrderedMap[string, *OrderedMap[string, *Operation]]()
-	l.activeFlushes++
-
-	// Build a lightweight loader for flushing while still under lock to avoid racy reads of fields.
-	flushLoader := l.newFlushLoader(snapshot)
-
-	l.cond.L.Unlock()
-
-	l.logger.Debug("async flush started", zap.Int("active_flushes", l.activeFlushes))
-
-	go func() {
-		// cleanup defer
-		defer func() {
-			l.cond.L.Lock()
-			l.activeFlushes--
-			l.cond.Broadcast()
-			l.cond.L.Unlock()
-		}()
-
-		// Disallow cancellation of the context to prevent holes in the data with parallel flushes
-		if l.maxParallelFlushes > 1 {
-			ctx = context.WithoutCancel(ctx)
-		}
-
-		start := time.Now()
-		rowFlushedCount, err := flushLoader.Flush(ctx, outputModuleHash, cursor, lastFinalBlock)
-		if err != nil {
-			l.logger.Warn("async flush failed after retries", zap.Error(err))
-			if l.onFlushError != nil {
-				l.onFlushError(err)
-			}
-			return
-		}
-
-		took := time.Since(start)
-		l.logger.Debug("async flush complete",
-			zap.Int("row_count", rowFlushedCount),
-			zap.Duration("took", took))
-
-		// Notify observer outside the lock
-		if l.onFlush != nil {
-			l.onFlush(rowFlushedCount, took)
-		}
-	}()
 }
 
 func (l *Loader) LoadTables() error {

--- a/db/db.go
+++ b/db/db.go
@@ -454,11 +454,8 @@ func (l *Loader) HasTable(tableName string) bool {
 }
 
 // GetActiveFlushesNum returns the current number of in-flight async flushes.
-func (l *Loader) GetActiveFlushesNum() int {
-	l.cond.L.Lock()
-	defer l.cond.L.Unlock()
-	return l.activeFlushes
-}
+// This value is approximate and may be racy; it is intended for metrics only.
+func (l *Loader) GetActiveFlushesNum() int { return l.activeFlushes }
 
 func (l *Loader) MarshalLogObject(encoder zapcore.ObjectEncoder) error {
 	encoder.AddUint64("entries_count", l.entriesCount)

--- a/db/flush.go
+++ b/db/flush.go
@@ -22,9 +22,6 @@ func (l *Loader) Flush(ctx context.Context, outputModuleHash string, cursor *sin
 				zap.Int("row_count", rowFlushedCount),
 				zap.Duration("took", time.Since(startAt)),
 			)
-			if l.onFlush != nil {
-				l.onFlush(rowFlushedCount, time.Since(startAt))
-			}
 			return rowFlushedCount, nil
 		}
 		l.logger.Warn("Flush attempt failed",

--- a/db/operations_test.go
+++ b/db/operations_test.go
@@ -19,7 +19,7 @@ func TestEscapeColumns(t *testing.T) {
 		t.Skip(`PG_DSN not set, please specify PG_DSN to run this test, example: PG_DSN="psql://dev-node:insecure-change-me-in-prod@localhost:5432/dev-node?enable_incremental_sort=off&sslmode=disable"`)
 	}
 
-	dbLoader, err := NewLoader(dsn, 0, 0, 0, 1, OnModuleHashMismatchIgnore, nil, zlog, tracer)
+	dbLoader, err := NewLoader(dsn, 0, 0, 0, OnModuleHashMismatchIgnore, nil, zlog, tracer)
 	require.NoError(t, err)
 
 	tx, err := dbLoader.DB.Begin()
@@ -68,7 +68,7 @@ func TestEscapeValues(t *testing.T) {
 		t.Skip(`PG_DSN not set, please specify PG_DSN to run this test, example: PG_DSN="psql://dev-node:insecure-change-me-in-prod@localhost:5432/dev-node?enable_incremental_sort=off&sslmode=disable"`)
 	}
 
-	dbLoader, err := NewLoader(dsn, 0, 0, 0, 1, OnModuleHashMismatchIgnore, nil, zlog, tracer)
+	dbLoader, err := NewLoader(dsn, 0, 0, 0, OnModuleHashMismatchIgnore, nil, zlog, tracer)
 	require.NoError(t, err)
 
 	tx, err := dbLoader.DB.Begin()

--- a/db/testing.go
+++ b/db/testing.go
@@ -15,7 +15,7 @@ func NewTestLoader(
 	tables map[string]*TableInfo,
 ) (*Loader, *TestTx) {
 
-	loader, err := NewLoader("psql://x:5432/x", 0, 0, 0, 1, OnModuleHashMismatchIgnore, nil, zlog, tracer)
+	loader, err := NewLoader("psql://x:5432/x", 0, 0, 0, OnModuleHashMismatchIgnore, nil, zlog, tracer)
 	if err != nil {
 		panic(err)
 	}

--- a/sinker/metrics.go
+++ b/sinker/metrics.go
@@ -22,5 +22,3 @@ var DatabaseChangesCount = metrics.NewCounter("substreams_sink_postgres_db_chang
 
 var HeadBlockNumber = metrics.NewHeadBlockNumber("substreams_sink_postgres")
 var HeadBlockTimeDrift = metrics.NewHeadTimeDrift("substreams_sink_postgres")
-
-var ActiveFlushes = metrics.NewGauge("substreams_sink_postgres_active_flushes", "Current number of active async flushes")

--- a/sinker/metrics.go
+++ b/sinker/metrics.go
@@ -14,11 +14,5 @@ var FlushCount = metrics.NewCounter("substreams_sink_postgres_store_flush_count"
 var FlushedRowsCount = metrics.NewCounter("substreams_sink_postgres_flushed_rows_count", "The number of flushed rows so far")
 var FlushDuration = metrics.NewCounter("substreams_sink_postgres_store_flush_duration", "The amount of time spent flushing cache to db (in nanoseconds)")
 
-// Performance profiling metrics
-var ProtobufDecodeDuration = metrics.NewCounter("substreams_sink_postgres_proto_decode_duration", "Time spent decoding protobuf messages (in nanoseconds)")
-var ProtobufMessageSize = metrics.NewCounter("substreams_sink_postgres_proto_message_size", "Size of protobuf messages in bytes")
-var DatabaseChangesDuration = metrics.NewCounter("substreams_sink_postgres_db_changes_duration", "Time spent applying database changes (in nanoseconds)")
-var DatabaseChangesCount = metrics.NewCounter("substreams_sink_postgres_db_changes_count", "Number of database changes processed")
-
 var HeadBlockNumber = metrics.NewHeadBlockNumber("substreams_sink_postgres")
 var HeadBlockTimeDrift = metrics.NewHeadTimeDrift("substreams_sink_postgres")

--- a/sinker/sinker.go
+++ b/sinker/sinker.go
@@ -163,11 +163,8 @@ func (s *SQLSinker) HandleBlockScopedData(ctx context.Context, data *pbsubstream
 		)
 
 		s.loader.FlushAsync(ctx, s.OutputModuleHash(), cursor, data.FinalBlockHeight)
-
+		// Update lastAppliedBlockNum after triggering async flush
 		s.lastAppliedBlockNum = &data.Clock.Number
-		ActiveFlushes.SetUint64(uint64(s.loader.GetActiveFlushesNum()))
-		HeadBlockTimeDrift.SetBlockTime(data.Clock.GetTimestamp().AsTime())
-		HeadBlockNumber.SetUint64(data.Clock.GetNumber())
 	}
 
 	return nil

--- a/sinker/sinker.go
+++ b/sinker/sinker.go
@@ -32,7 +32,7 @@ type SQLSinker struct {
 }
 
 func New(sink *sink.Sinker, loader *db.Loader, logger *zap.Logger, tracer logging.Tracer) (*SQLSinker, error) {
-	s := &SQLSinker{
+	return &SQLSinker{
 		Shutter: shutter.New(),
 		Sinker:  sink,
 
@@ -42,22 +42,7 @@ func New(sink *sink.Sinker, loader *db.Loader, logger *zap.Logger, tracer loggin
 
 		stats:               NewStats(logger),
 		lastAppliedBlockNum: nil,
-	}
-
-	// Register a flush observer to update metrics and stats for both sync and async flushes
-	loader.SetOnFlush(func(rows int, dur time.Duration) {
-		FlushCount.AddInt(1)
-		FlushedRowsCount.AddInt(rows)
-		FlushDuration.AddInt64(dur.Nanoseconds())
-		s.stats.RecordFlushDuration(dur)
-	})
-
-	// Register an error observer so any async flush failure shuts down the sinker
-	loader.SetOnFlushError(func(err error) {
-		s.Shutdown(fmt.Errorf("async flush failed: %w", err))
-	})
-
-	return s, nil
+	}, nil
 }
 
 func (s *SQLSinker) Run(ctx context.Context) {
@@ -84,13 +69,12 @@ func (s *SQLSinker) Run(ctx context.Context) {
 
 	s.Sinker.OnTerminating(s.Shutdown)
 	s.OnTerminating(func(err error) {
-		s.logger.Info("sql sinker terminating", zap.Stringer("last_block_written", s.stats.lastBlock))
-		s.loader.WaitForAllFlushes()
 		s.stats.LogNow()
-		s.stats.Close()
+		s.logger.Info("sql sinker terminating", zap.Stringer("last_block_written", s.stats.lastBlock))
 		s.Sinker.Shutdown(err)
 	})
 
+	s.OnTerminating(func(_ error) { s.stats.Close() })
 	s.stats.OnTerminated(func(err error) { s.Shutdown(err) })
 
 	logEach := 15 * time.Second
@@ -127,26 +111,14 @@ func (s *SQLSinker) HandleBlockScopedData(ctx context.Context, data *pbsubstream
 		// We do not use UnmarshalTo here because we need to parse an older proto type and
 		// UnmarshalTo enforces the type check. So we check manually the `TypeUrl` above and we use
 		// `Unmarshal` instead which only deals with the bytes value.
-
-		// Measure protobuf decoding performance
-		ProtobufMessageSize.AddInt(len(mapOutput.Value))
-		decodeStart := time.Now()
 		if err := proto.Unmarshal(mapOutput.Value, dbChanges); err != nil {
 			return fmt.Errorf("unmarshal database changes: %w", err)
 		}
-		ProtobufDecodeDuration.AddInt64(time.Since(decodeStart).Nanoseconds())
 
-		// Measure database changes application performance
-		applyStart := time.Now()
 		if err := s.applyDatabaseChanges(dbChanges, data.Clock.Number, data.FinalBlockHeight); err != nil {
 			return fmt.Errorf("apply database changes: %w", err)
 		}
-		DatabaseChangesDuration.AddInt64(time.Since(applyStart).Nanoseconds())
-		DatabaseChangesCount.AddInt(len(dbChanges.TableChanges))
 	}
-	// Update stats with the current block for logging
-	s.stats.RecordBlock(cursor.Block())
-
 	if s.lastAppliedBlockNum == nil {
 		s.lastAppliedBlockNum = &data.Clock.Number
 	}
@@ -154,7 +126,7 @@ func (s *SQLSinker) HandleBlockScopedData(ctx context.Context, data *pbsubstream
 	blockFlushNeeded := s.batchBlockModulo(isLive) > 0 && data.Clock.Number-*s.lastAppliedBlockNum >= s.batchBlockModulo(isLive)
 	rowFlushNeeded := s.loader.FlushNeeded()
 	if blockFlushNeeded || rowFlushNeeded {
-		s.logger.Debug("triggering async flush",
+		s.logger.Debug("flushing to database",
 			zap.Stringer("block", cursor.Block()),
 			zap.Uint64("last_flushed_block", *s.lastAppliedBlockNum),
 			zap.Bool("is_live", *isLive),
@@ -162,8 +134,30 @@ func (s *SQLSinker) HandleBlockScopedData(ctx context.Context, data *pbsubstream
 			zap.Bool("row_flush_interval_reached", rowFlushNeeded),
 		)
 
-		s.loader.FlushAsync(ctx, s.OutputModuleHash(), cursor, data.FinalBlockHeight)
-		// Update lastAppliedBlockNum after triggering async flush
+		flushStart := time.Now()
+		rowFlushedCount, err := s.loader.Flush(ctx, s.OutputModuleHash(), cursor, data.FinalBlockHeight)
+		if err != nil {
+			return fmt.Errorf("failed to flush at block %s: %w", cursor.Block(), err)
+		}
+
+		flushDuration := time.Since(flushStart)
+		if flushDuration > 5*time.Second {
+			level := zap.InfoLevel
+			if flushDuration > 30*time.Second {
+				level = zap.WarnLevel
+			}
+
+			s.logger.Check(level, "flush to database took a long time to complete, could cause long sync time along the road").Write(zap.Duration("took", flushDuration))
+		}
+
+		FlushCount.Inc()
+		FlushedRowsCount.AddInt(rowFlushedCount)
+		FlushDuration.AddInt64(flushDuration.Nanoseconds())
+		HeadBlockTimeDrift.SetBlockTime(data.Clock.GetTimestamp().AsTime())
+		HeadBlockNumber.SetUint64(data.Clock.GetNumber())
+
+		s.stats.RecordBlock(cursor.Block())
+		s.stats.RecordFlushDuration(flushDuration)
 		s.lastAppliedBlockNum = &data.Clock.Number
 	}
 
@@ -230,15 +224,7 @@ func (s *SQLSinker) applyDatabaseChanges(dbChanges *pbdatabase.DatabaseChanges, 
 
 func (s *SQLSinker) HandleBlockRangeCompletion(ctx context.Context, cursor *sink.Cursor) error {
 
-	s.logger.Info("stream completed, waiting for async flushes to finish", zap.Stringer("block", cursor.Block()))
-	s.loader.WaitForAllFlushes()
-
-	// If the upstream context has been canceled, skip the final flush
-	if err := ctx.Err(); err != nil {
-		s.logger.Warn("completion flush skipped: context canceled, exiting without final flush", zap.Error(err))
-		return nil
-	}
-	s.logger.Info("stream completed, flushing remaining entries to database", zap.Stringer("block", cursor.Block()))
+	s.logger.Info("stream completed, flushing to database", zap.Stringer("block", cursor.Block()))
 	_, err := s.loader.Flush(ctx, s.OutputModuleHash(), cursor, cursor.Block().Num())
 	if err != nil {
 		return fmt.Errorf("failed to flush %s block on completion: %w", cursor.Block(), err)

--- a/sinker/sinker_test.go
+++ b/sinker/sinker_test.go
@@ -220,8 +220,6 @@ func TestInserts(t *testing.T) {
 
 			for _, evt := range test.events {
 				if evt.undoSignal {
-					// Ensure previously triggered async flushes are completed before revert
-					l.WaitForAllFlushes()
 					cursor := simpleCursor(evt.blockNum, evt.libNum)
 					err := sinker.HandleBlockUndoSignal(ctx, &pbsubstreamsrpc.BlockUndoSignal{
 						LastValidBlock:  &pbsubstreams.BlockRef{Id: fmt.Sprintf("%d", evt.blockNum), Number: evt.blockNum},
@@ -238,9 +236,6 @@ func TestInserts(t *testing.T) {
 				)
 				require.NoError(t, err)
 			}
-
-			// Ensure any asynchronous flushes have completed before asserting results
-			l.WaitForAllFlushes()
 
 			results := tx.Results()
 			assert.Equal(t, test.expectSQL, results)


### PR DESCRIPTION
Async flushes proved to be only marginally more performant than sync flushes, while adding complexity with synchorization and potential holes in data on ungraceful shutdown.
 
We took another approach to solve Solana issues on the substreams level.

In the future we can continue to work in the `async-flushes` branch: https://github.com/pinax-network/substreams-sink-sql/tree/async-flushes