### PR TITLE
Allow zero undo buffer for clickhouse

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -103,9 +103,11 @@ func NewLoader(
 		l.handleReorgs = *handleReorgs
 	}
 
-	if l.handleReorgs && l.getDialect().OnlyInserts() {
-		return nil, fmt.Errorf("driver %s does not support reorg handling. You must use set a non-zero undo-buffer-size", dsn.driver)
-	}
+	// ClickHouse currently does not support reorg handling properly
+	// This is a temporary workaround to allow ClickHouse to quietly accept reorgs without deleting anything from the database
+	// if l.handleReorgs && l.getDialect().OnlyInserts() {
+	// 	return nil, fmt.Errorf("driver %s does not support reorg handling. You must use set a non-zero undo-buffer-size", dsn.driver)
+	// }
 
 	logger.Info("created new DB loader",
 		zap.Int("batch_block_flush_interval", batchBlockFlushInterval),
@@ -217,7 +219,11 @@ func (l *Loader) LoadTables() error {
 		return &SystemTableError{fmt.Errorf(`%s.%s table is not found`, EscapeIdentifier(l.schema), CURSORS_TABLE)}
 	}
 	if l.handleReorgs && !seenHistoryTable {
-		return &SystemTableError{fmt.Errorf("%s.%s table is not found and reorgs handling is enabled", EscapeIdentifier(l.schema), HISTORY_TABLE)}
+		l.logger.Warn("history table not found but reorg handling is enabled",
+			zap.String("schema_name", l.schema),
+			zap.String("table_name", HISTORY_TABLE),
+		)
+		// return &SystemTableError{fmt.Errorf("%s.%s table is not found and reorgs handling is enabled", EscapeIdentifier(l.schema), HISTORY_TABLE)}
 	}
 
 	l.cursorTable = l.tables[CURSORS_TABLE]

--- a/db/dialect_clickhouse.go
+++ b/db/dialect_clickhouse.go
@@ -100,7 +100,10 @@ func (d clickhouseDialect) Flush(tx Tx, ctx context.Context, l *Loader, outputMo
 }
 
 func (d clickhouseDialect) Revert(tx Tx, ctx context.Context, l *Loader, lastValidFinalBlock uint64) error {
-	return fmt.Errorf("clickhouse driver does not support reorg management.")
+	l.logger.Warn("received UNDO signal but ClickHouse driver does not support reorg handling - data already flushed to database cannot be reverted, ignoring UNDO",
+		zap.Uint64("last_valid_block", lastValidFinalBlock),
+	)
+	return nil
 }
 
 func (d clickhouseDialect) GetCreateCursorQuery(schema string, withPostgraphile bool) string {


### PR DESCRIPTION
This pull request introduces temporary workarounds to allow ClickHouse to quietly accept blockchain reorgs without enforcing strict reorg handling or requiring the presence of a history table. Instead of returning errors, the code now logs warnings when encountering unsupported reorg scenarios or missing tables, improving compatibility with ClickHouse at the expense of strict data integrity enforcement.
