### PR TITLE
Add live drift reconnect threshold to trigger backfilling

### DIFF
--- a/cmd/substreams-sink-sql/run.go
+++ b/cmd/substreams-sink-sql/run.go
@@ -33,6 +33,7 @@ var sinkRunCmd = Command(sinkRunE,
 		flags.Int("live-block-flush-interval", 1, "When processing in live mode, flush every N blocks.")
 		flags.Int("flush-interval", 0, "(deprecated) please use --batch-block-flush-interval instead")
 		flags.String("idle-timeout", "", "Duration to wait without data messages before triggering a reconnect, e.g. '10m', '1h'. Waiting for first block doesn't count as idle.")
+		flags.String("live-drift-reconnect", "1h", "When in live mode, force reconnect if block timestamp drift exceeds this duration, triggering backfilling. Set to 0 to disable.")
 		flags.StringP("endpoint", "e", "", "Specify the substreams endpoint, ex: `mainnet.eth.streamingfast.io:443`")
 	}),
 	Example("substreams-sink-sql run 'postgres://localhost:5432/posgres?sslmode=disable' uniswap-v3@v0.2.10"),
@@ -85,6 +86,16 @@ func sinkRunE(cmd *cobra.Command, args []string) error {
 		}
 	}
 
+	liveDriftReconnect := sflags.MustGetString(cmd, "live-drift-reconnect")
+	var liveDriftReconnectDuration time.Duration
+	if liveDriftReconnect != "" {
+		var err error
+		liveDriftReconnectDuration, err = time.ParseDuration(liveDriftReconnect)
+		if err != nil {
+			return fmt.Errorf("invalid live-drift-reconnect duration: %w", err)
+		}
+	}
+
 	sink, err := sink.NewFromViper(
 		cmd,
 		supportedOutputTypes,
@@ -110,7 +121,7 @@ func sinkRunE(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("new db loader: %w", err)
 	}
 
-	postgresSinker, err := sinker.New(sink, dbLoader, zlog, tracer, manifestPath)
+	postgresSinker, err := sinker.New(sink, dbLoader, zlog, tracer, manifestPath, liveDriftReconnectDuration)
 	if err != nil {
 		return fmt.Errorf("unable to setup postgres sinker: %w", err)
 	}

--- a/sinker/sinker.go
+++ b/sinker/sinker.go
@@ -28,12 +28,13 @@ type SQLSinker struct {
 	logger *zap.Logger
 	tracer logging.Tracer
 
-	stats               *Stats
-	lastAppliedBlockNum *uint64
-	manifestPath        string // Store manifest path for metrics
+	stats                      *Stats
+	lastAppliedBlockNum        *uint64
+	manifestPath               string
+	liveDriftReconnectDuration time.Duration
 }
 
-func New(sink *sink.Sinker, loader *db.Loader, logger *zap.Logger, tracer logging.Tracer, manifestPath string) (*SQLSinker, error) {
+func New(sink *sink.Sinker, loader *db.Loader, logger *zap.Logger, tracer logging.Tracer, manifestPath string, liveDriftReconnectDuration time.Duration) (*SQLSinker, error) {
 	return &SQLSinker{
 		Shutter: shutter.New(),
 		Sinker:  sink,
@@ -42,9 +43,10 @@ func New(sink *sink.Sinker, loader *db.Loader, logger *zap.Logger, tracer loggin
 		logger: logger,
 		tracer: tracer,
 
-		stats:               NewStats(logger),
-		lastAppliedBlockNum: nil,
-		manifestPath:        manifestPath,
+		stats:                      NewStats(logger),
+		lastAppliedBlockNum:        nil,
+		manifestPath:               manifestPath,
+		liveDriftReconnectDuration: liveDriftReconnectDuration,
 	}, nil
 }
 
@@ -119,6 +121,14 @@ func (s *SQLSinker) HandleBlockScopedData(ctx context.Context, data *pbsubstream
 
 	if output.Name != s.OutputModuleName() {
 		return fmt.Errorf("received data from wrong output module, expected to received from %q but got module's output for %q", s.OutputModuleName(), output.Name)
+	}
+
+	if s.liveDriftReconnectDuration > 0 && isLive != nil && *isLive {
+		blockTime := data.Clock.GetTimestamp().AsTime()
+		drift := time.Since(blockTime)
+		if drift > s.liveDriftReconnectDuration {
+			return fmt.Errorf("live mode drift exceeded threshold: block timestamp is %s behind current time (threshold: %s), triggering reconnect for backfilling", drift, s.liveDriftReconnectDuration)
+		}
 	}
 
 	dbChanges := &pbdatabase.DatabaseChanges{}


### PR DESCRIPTION
This pull request introduces a new feature to the live mode operation of the SQL sinker, allowing forced reconnects if the block timestamp drift exceeds a configurable threshold. This is intended to improve data freshness by triggering backfilling when the live data stream lags behind real time. The implementation includes a new CLI flag, propagates the configuration through the codebase, and enforces the drift check during block handling.
