### PR TITLE
Fix drift: record block time on every block, not just flushes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -201,4 +201,4 @@ replace github.com/jimsmart/schema => github.com/streamingfast/schema v0.0.0-202
 
 replace github.com/ClickHouse/clickhouse-go/v2 => github.com/YaroShkvorets/clickhouse-go/v2 v2.26.0-sink-sql
 
-replace github.com/streamingfast/substreams-sink => github.com/pinax-network/substreams-sink-go v0.5.9
+replace github.com/streamingfast/substreams-sink => github.com/pinax-network/substreams-sink-go v0.5.10

--- a/go.sum
+++ b/go.sum
@@ -489,8 +489,8 @@ github.com/pierrec/lz4/v4 v4.1.22 h1:cKFw6uJDK+/gfw5BcDL0JL5aBsAFdsIT18eRtLj7VIU
 github.com/pierrec/lz4/v4 v4.1.22/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
 github.com/pinax-network/graph-networks-libs/packages/golang v0.7.0 h1:chRRgzgzmFzICbB/8ybY1IDqvxVgjV415M0AsIYmUHQ=
 github.com/pinax-network/graph-networks-libs/packages/golang v0.7.0/go.mod h1:G76L6ql7YCygVzN45BmtSBqA+qwcDuFWMM42tDnGJbE=
-github.com/pinax-network/substreams-sink-go v0.5.9 h1:qN5QJabhrREziir9yaLJi4UW69JZ3LTzNLi/uYHdXLo=
-github.com/pinax-network/substreams-sink-go v0.5.9/go.mod h1:Pb3i0VSRpzs6RzPNN+0mzQPGH62mrst7MQqDn3tA3xo=
+github.com/pinax-network/substreams-sink-go v0.5.10 h1:UoYRoJn3/lXl6+f0O5Zp3pLNu9cXM/IcTgFcVS2hFpw=
+github.com/pinax-network/substreams-sink-go v0.5.10/go.mod h1:Pb3i0VSRpzs6RzPNN+0mzQPGH62mrst7MQqDn3tA3xo=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c h1:+mdjkGKdHQG3305AYmdv1U2eRNDiU2ErMBj1gwrq8eQ=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c/go.mod h1:7rwL4CYBLnjLxUqIJNnCWiEdr3bn6IUYi15bNlnbCCU=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/sinker/sinker.go
+++ b/sinker/sinker.go
@@ -150,6 +150,8 @@ func (s *SQLSinker) HandleBlockScopedData(ctx context.Context, data *pbsubstream
 			return fmt.Errorf("apply database changes: %w", err)
 		}
 	}
+	s.stats.RecordBlockTime(data.Clock.GetTimestamp().AsTime())
+
 	if s.lastAppliedBlockNum == nil {
 		s.lastAppliedBlockNum = &data.Clock.Number
 	}
@@ -189,7 +191,6 @@ func (s *SQLSinker) HandleBlockScopedData(ctx context.Context, data *pbsubstream
 		HeadBlockNumber.SetUint64(data.Clock.GetNumber())
 
 		s.stats.RecordBlock(cursor.Block())
-		s.stats.RecordBlockTime(data.Clock.GetTimestamp().AsTime())
 		s.stats.RecordFlush(flushDuration)
 		s.lastAppliedBlockNum = &data.Clock.Number
 	}


### PR DESCRIPTION
Block time was only recorded inside the flush condition, so before the first flush `time.Since(zero)` produced ~56 years of drift (1774391865 seconds).

Moved `RecordBlockTime` to run on every incoming block.