### PR TITLE
[codex] Support ClickHouse EPHEMERAL columns

### DIFF
--- a/db/clickhouse_schema.go
+++ b/db/clickhouse_schema.go
@@ -21,7 +21,6 @@ const clickhouseInsertableColumnsQuery = `
 	WHERE
 		database = $1
 		AND table = $2
-		AND is_subcolumn = 0
 	ORDER BY
 		position
 `
@@ -43,6 +42,9 @@ func (l *Loader) loadClickhouseTables() error {
 		)
 
 		if schemaName != l.schema {
+			continue
+		}
+		if shouldSkipClickhouseTable(tableName) {
 			continue
 		}
 
@@ -135,6 +137,10 @@ func shouldSkipClickhouseColumn(defaultKind string) bool {
 	default:
 		return false
 	}
+}
+
+func shouldSkipClickhouseTable(tableName string) bool {
+	return strings.HasPrefix(tableName, ".")
 }
 
 func (l *Loader) validateCursorTableInfo(columns map[string]*ColumnInfo) error {

--- a/db/clickhouse_schema.go
+++ b/db/clickhouse_schema.go
@@ -1,0 +1,171 @@
+package db
+
+import (
+	"database/sql"
+	"fmt"
+	"strings"
+	"time"
+
+	chcolumn "github.com/ClickHouse/clickhouse-go/v2/lib/column"
+	"github.com/jimsmart/schema"
+	"go.uber.org/zap"
+)
+
+const clickhouseInsertableColumnsQuery = `
+	SELECT
+		name,
+		type,
+		default_kind
+	FROM
+		system.columns
+	WHERE
+		database = $1
+		AND table = $2
+		AND is_subcolumn = 0
+	ORDER BY
+		position
+`
+
+func (l *Loader) loadClickhouseTables() error {
+	tableNames, err := schema.TableNames(l.DB)
+	if err != nil {
+		return fmt.Errorf("retrieving table names: %w", err)
+	}
+
+	seenCursorTable := false
+	seenHistoryTable := false
+	for _, schemaTableName := range tableNames {
+		schemaName := schemaTableName[0]
+		tableName := schemaTableName[1]
+		l.logger.Debug("processing schema's table",
+			zap.String("schema_name", schemaName),
+			zap.String("table_name", tableName),
+		)
+
+		if schemaName != l.schema {
+			continue
+		}
+
+		columnByName, err := l.loadClickhouseInsertableColumns(schemaName, tableName)
+		if err != nil {
+			return fmt.Errorf("get clickhouse columns for %s.%s: %w", schemaName, tableName, err)
+		}
+
+		if tableName == CURSORS_TABLE {
+			if err := l.validateCursorTableInfo(columnByName); err != nil {
+				return fmt.Errorf("invalid cursors table: %w", err)
+			}
+
+			seenCursorTable = true
+		}
+		if tableName == HISTORY_TABLE {
+			seenHistoryTable = true
+		}
+
+		key, err := schema.PrimaryKey(l.DB, schemaName, tableName)
+		if err != nil {
+			return fmt.Errorf("get primary key: %w", err)
+		}
+
+		l.tables[tableName], err = NewTableInfo(schemaName, tableName, key, columnByName)
+		if err != nil {
+			return fmt.Errorf("invalid table: %w", err)
+		}
+	}
+
+	if !seenCursorTable {
+		return &SystemTableError{fmt.Errorf(`%s.%s table is not found`, EscapeIdentifier(l.schema), CURSORS_TABLE)}
+	}
+	if l.handleReorgs && !seenHistoryTable {
+		l.logger.Warn("history table not found but reorg handling is enabled",
+			zap.String("schema_name", l.schema),
+			zap.String("table_name", HISTORY_TABLE),
+		)
+	}
+
+	l.cursorTable = l.tables[CURSORS_TABLE]
+
+	return nil
+}
+
+func (l *Loader) loadClickhouseInsertableColumns(schemaName, tableName string) (map[string]*ColumnInfo, error) {
+	rows, err := l.Query(clickhouseInsertableColumnsQuery, schemaName, tableName)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	columnByName := map[string]*ColumnInfo{}
+	for rows.Next() {
+		var name string
+		var typeName string
+		var defaultKind sql.NullString
+		if err := rows.Scan(&name, &typeName, &defaultKind); err != nil {
+			return nil, fmt.Errorf("scan clickhouse column metadata: %w", err)
+		}
+
+		if shouldSkipClickhouseColumn(defaultKind.String) {
+			continue
+		}
+
+		column, err := chcolumn.Type(typeName).Column(name, time.UTC)
+		if err != nil {
+			return nil, fmt.Errorf("parse clickhouse column %q type %q: %w", name, typeName, err)
+		}
+
+		columnByName[name] = &ColumnInfo{
+			name:             name,
+			escapedName:      EscapeIdentifier(name),
+			databaseTypeName: typeName,
+			scanType:         column.ScanType(),
+		}
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("read clickhouse column metadata: %w", err)
+	}
+
+	return columnByName, nil
+}
+
+func shouldSkipClickhouseColumn(defaultKind string) bool {
+	switch strings.ToUpper(defaultKind) {
+	case "ALIAS", "MATERIALIZED":
+		return true
+	default:
+		return false
+	}
+}
+
+func (l *Loader) validateCursorTableInfo(columns map[string]*ColumnInfo) error {
+	if len(columns) != 4 {
+		return &SystemTableError{fmt.Errorf("table requires 4 columns ('id', 'cursor', 'block_num', 'block_id')")}
+	}
+
+	columnsCheck := map[string]string{
+		"block_num": "int64",
+		"block_id":  "string",
+		"cursor":    "string",
+		"id":        "string",
+	}
+	for columnName, column := range columns {
+		expectedType, found := columnsCheck[columnName]
+		if !found {
+			return &SystemTableError{fmt.Errorf("unexpected column %q in cursors table", columnName)}
+		}
+
+		actualType := column.scanType.Kind().String()
+		if expectedType != actualType {
+			return &SystemTableError{fmt.Errorf("column %q has invalid type, expected %q has %q", columnName, expectedType, actualType)}
+		}
+		delete(columnsCheck, columnName)
+	}
+
+	if len(columnsCheck) != 0 {
+		for columnName := range columnsCheck {
+			return &SystemTableError{fmt.Errorf("missing expected column %q in cursors table", columnName)}
+		}
+	}
+
+	return nil
+}

--- a/db/clickhouse_schema_test.go
+++ b/db/clickhouse_schema_test.go
@@ -1,0 +1,53 @@
+package db
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadClickhouseInsertableColumns(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	loader := &Loader{DB: db}
+
+	rows := sqlmock.NewRows([]string{"name", "type", "default_kind"}).
+		AddRow("block_num", "UInt32", "").
+		AddRow("block_hash", "String", "EPHEMERAL").
+		AddRow("timestamp", "DateTime('UTC')", "").
+		AddRow("minute", "UInt32", "MATERIALIZED").
+		AddRow("contract_alias", "String", "ALIAS")
+
+	mock.ExpectQuery("FROM\\s+system\\.columns").
+		WithArgs("default", "erc20_balances").
+		WillReturnRows(rows)
+
+	columns, err := loader.loadClickhouseInsertableColumns("default", "erc20_balances")
+	require.NoError(t, err)
+
+	assert.Contains(t, columns, "block_num")
+	assert.Contains(t, columns, "block_hash")
+	assert.Contains(t, columns, "timestamp")
+	assert.NotContains(t, columns, "minute")
+	assert.NotContains(t, columns, "contract_alias")
+
+	assert.Equal(t, reflect.TypeOf(uint32(0)), columns["block_num"].scanType)
+	assert.Equal(t, reflect.TypeOf(""), columns["block_hash"].scanType)
+	assert.Equal(t, reflect.TypeOf(time.Time{}), columns["timestamp"].scanType)
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestShouldSkipClickhouseColumn(t *testing.T) {
+	assert.False(t, shouldSkipClickhouseColumn(""))
+	assert.False(t, shouldSkipClickhouseColumn("DEFAULT"))
+	assert.False(t, shouldSkipClickhouseColumn("EPHEMERAL"))
+	assert.True(t, shouldSkipClickhouseColumn("materialized"))
+	assert.True(t, shouldSkipClickhouseColumn("ALIAS"))
+}

--- a/db/clickhouse_schema_test.go
+++ b/db/clickhouse_schema_test.go
@@ -51,3 +51,10 @@ func TestShouldSkipClickhouseColumn(t *testing.T) {
 	assert.True(t, shouldSkipClickhouseColumn("materialized"))
 	assert.True(t, shouldSkipClickhouseColumn("ALIAS"))
 }
+
+func TestShouldSkipClickhouseTable(t *testing.T) {
+	assert.True(t, shouldSkipClickhouseTable(".inner_id.0e667ee5-8e5b-4943-98cc-36325c087ea5"))
+	assert.True(t, shouldSkipClickhouseTable(".inner.my_mv"))
+	assert.False(t, shouldSkipClickhouseTable("erc20_balances"))
+	assert.False(t, shouldSkipClickhouseTable(CURSORS_TABLE))
+}

--- a/db/db.go
+++ b/db/db.go
@@ -168,6 +168,10 @@ func (l *Loader) GetBufferedRowCount() int {
 }
 
 func (l *Loader) LoadTables() error {
+	if _, ok := l.getDialect().(clickhouseDialect); ok {
+		return l.loadClickhouseTables()
+	}
+
 	schemaTables, err := schema.Tables(l.DB)
 	if err != nil {
 		return fmt.Errorf("retrieving table and schema: %w", err)

--- a/go.mod
+++ b/go.mod
@@ -38,6 +38,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.6.3 // indirect
 	github.com/AzureAD/microsoft-authentication-library-for-go v1.6.0 // indirect
 	github.com/ClickHouse/ch-go v0.65.1 // indirect
+	github.com/DATA-DOG/go-sqlmock v1.5.2 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.30.0 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.54.0 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.54.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -86,6 +86,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/ClickHouse/ch-go v0.65.1 h1:SLuxmLl5Mjj44/XbINsK2HFvzqup0s6rwKLFH347ZhU=
 github.com/ClickHouse/ch-go v0.65.1/go.mod h1:bsodgURwmrkvkBe5jw1qnGDgyITsYErfONKAHn05nv4=
+github.com/DATA-DOG/go-sqlmock v1.5.2 h1:OcvFkGmslmlZibjAjaHm3L//6LiuBgolP7OputlJIzU=
+github.com/DATA-DOG/go-sqlmock v1.5.2/go.mod h1:88MAG/4G7SMwSE3CeA0ZKzrT5CiOU3OJ+JlNzwDqpNU=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.30.0 h1:sBEjpZlNHzK1voKq9695PJSX2o5NEXl7/OL3coiIY0c=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.30.0/go.mod h1:P4WPRUkOhJC13W//jWpyfJNDAIpvRbAUIYLX/4jtlE0=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.54.0 h1:lhhYARPUu3LmHysQ/igznQphfzynnqI3D75oUyw1HXk=
@@ -412,6 +414,7 @@ github.com/keybase/go-keychain v0.0.1 h1:way+bWYa6lDppZoZcgMbYsvC7GxljxrskdNInRt
 github.com/keybase/go-keychain v0.0.1/go.mod h1:PdEILRW3i9D8JcdM+FmY6RwkHGnhHxXwkPPMeUgOK1k=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
+github.com/kisielk/sqlstruct v0.0.0-20201105191214-5f3e10d3ab46/go.mod h1:yyMNCyc/Ib3bDTKd379tNMpB/7/H5TjM2Y9QJ5THLbE=
 github.com/klauspost/compress v1.13.6/go.mod h1:/3/Vjq9QcHkK5uEr5lBEmyoZ1iFhe47etQ6QUkpK6sk=
 github.com/klauspost/compress v1.18.3 h1:9PJRvfbmTabkOX8moIpXPbMMbYN60bWImDDU7L+/6zw=
 github.com/klauspost/compress v1.18.3/go.mod h1:R0h/fSBs8DE4ENlcrlib3PsXS61voFxhIs2DeRhCvJ4=


### PR DESCRIPTION
## Summary
- load ClickHouse table metadata from `system.columns` instead of relying on `SELECT * LIMIT 0` for ClickHouse tables
- keep `EPHEMERAL` columns available to the sink while still filtering out `MATERIALIZED` and `ALIAS` generated columns
- add a regression test proving `EPHEMERAL` columns are preserved during ClickHouse schema introspection

## Root Cause
ClickHouse `EPHEMERAL` columns are not exposed through the generic `schema.Tables(...)` path used by `LoadTables()`, because that path depends on `SELECT * FROM table LIMIT 0` column metadata. As a result, the loader built `columnsByName` without `block_hash`, and flush failed when the incoming row still included that field.

## Fix
For ClickHouse only, `LoadTables()` now reads insertable column metadata from `system.columns`, converts ClickHouse types through the driver’s column parser, and skips only generated columns (`MATERIALIZED`, `ALIAS`). That keeps `EPHEMERAL` columns insertable without reintroducing generated columns that should not be written by the sink.

## Validation
- `go test ./db -run 'TestLoadClickhouseInsertableColumns|TestShouldSkipClickhouseColumn|TestUpsertUsesInsertForInsertOnlyDialects'`
