### PR TITLE
Reconnect on live (tier1) drift via session linear-handoff block

### DIFF
--- a/cmd/substreams-sink-sql/run.go
+++ b/cmd/substreams-sink-sql/run.go
@@ -33,7 +33,7 @@ var sinkRunCmd = Command(sinkRunE,
 		flags.Int("live-block-flush-interval", 1, "When processing in live mode, flush every N blocks.")
 		flags.Int("flush-interval", 0, "(deprecated) please use --batch-block-flush-interval instead")
 		flags.String("idle-timeout", "", "Duration to wait without data messages before triggering a reconnect, e.g. '10m', '1h'. Waiting for first block doesn't count as idle.")
-		flags.String("live-drift-reconnect", "1h", "When in live mode, force reconnect if block timestamp drift exceeds this duration, triggering backfilling. Set to 0 to disable.")
+		flags.String("live-drift-reconnect", "", "When set, force a reconnect (triggering tier2 parallel backfilling) if, while streaming live (tier1), the block timestamp drift exceeds this duration, e.g. '15m', '1h'. Disabled by default.")
 		flags.StringP("endpoint", "e", "", "Specify the substreams endpoint, ex: `mainnet.eth.streamingfast.io:443`")
 	}),
 	Example("substreams-sink-sql run 'postgres://localhost:5432/posgres?sslmode=disable' uniswap-v3@v0.2.10"),

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.25.0
 
 require (
 	github.com/ClickHouse/clickhouse-go/v2 v2.25.0
+	github.com/DATA-DOG/go-sqlmock v1.5.2
 	github.com/bobg/go-generics/v2 v2.2.2
 	github.com/drone/envsubst v1.0.3
 	github.com/golang/protobuf v1.5.4
@@ -38,7 +39,6 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.6.3 // indirect
 	github.com/AzureAD/microsoft-authentication-library-for-go v1.6.0 // indirect
 	github.com/ClickHouse/ch-go v0.65.1 // indirect
-	github.com/DATA-DOG/go-sqlmock v1.5.2 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.30.0 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.54.0 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.54.0 // indirect
@@ -202,4 +202,4 @@ replace github.com/jimsmart/schema => github.com/streamingfast/schema v0.0.0-202
 
 replace github.com/ClickHouse/clickhouse-go/v2 => github.com/YaroShkvorets/clickhouse-go/v2 v2.26.0-sink-sql
 
-replace github.com/streamingfast/substreams-sink => github.com/pinax-network/substreams-sink-go v0.5.10
+replace github.com/streamingfast/substreams-sink => github.com/pinax-network/substreams-sink-go v0.5.11

--- a/go.sum
+++ b/go.sum
@@ -492,8 +492,8 @@ github.com/pierrec/lz4/v4 v4.1.22 h1:cKFw6uJDK+/gfw5BcDL0JL5aBsAFdsIT18eRtLj7VIU
 github.com/pierrec/lz4/v4 v4.1.22/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
 github.com/pinax-network/graph-networks-libs/packages/golang v0.7.0 h1:chRRgzgzmFzICbB/8ybY1IDqvxVgjV415M0AsIYmUHQ=
 github.com/pinax-network/graph-networks-libs/packages/golang v0.7.0/go.mod h1:G76L6ql7YCygVzN45BmtSBqA+qwcDuFWMM42tDnGJbE=
-github.com/pinax-network/substreams-sink-go v0.5.10 h1:UoYRoJn3/lXl6+f0O5Zp3pLNu9cXM/IcTgFcVS2hFpw=
-github.com/pinax-network/substreams-sink-go v0.5.10/go.mod h1:Pb3i0VSRpzs6RzPNN+0mzQPGH62mrst7MQqDn3tA3xo=
+github.com/pinax-network/substreams-sink-go v0.5.11 h1:vYOoveTo6gh7HIRO3bxR0bZ+KR4iSmySodI+22pgM+M=
+github.com/pinax-network/substreams-sink-go v0.5.11/go.mod h1:Pb3i0VSRpzs6RzPNN+0mzQPGH62mrst7MQqDn3tA3xo=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c h1:+mdjkGKdHQG3305AYmdv1U2eRNDiU2ErMBj1gwrq8eQ=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c/go.mod h1:7rwL4CYBLnjLxUqIJNnCWiEdr3bn6IUYi15bNlnbCCU=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/sinker/sinker.go
+++ b/sinker/sinker.go
@@ -130,7 +130,7 @@ func (s *SQLSinker) HandleBlockScopedData(ctx context.Context, data *pbsubstream
 		return fmt.Errorf("received data from wrong output module, expected to received from %q but got module's output for %q", s.OutputModuleName(), output.Name)
 	}
 
-	if s.liveDriftReconnectDuration > 0 && isLive != nil && *isLive {
+	if s.liveDriftReconnectDuration > 0 && s.runningFromTier1(data.Clock.Number) {
 		blockTime := data.Clock.GetTimestamp().AsTime()
 		drift := time.Since(blockTime)
 		if drift > s.liveDriftReconnectDuration {
@@ -280,6 +280,28 @@ func (s *SQLSinker) HandleBlockRangeCompletion(ctx context.Context, cursor *sink
 
 func (s *SQLSinker) HandleBlockUndoSignal(ctx context.Context, data *pbsubstreamsrpc.BlockUndoSignal, cursor *sink.Cursor) error {
 	return s.loader.Revert(ctx, s.OutputModuleHash(), cursor, data.LastValidBlock.Number)
+}
+
+// runningFromTier1 reports whether the given block is being produced by live (tier1)
+// linear streaming rather than replayed from parallel (tier2) backprocessing. This is the
+// same notion the sink library logs as `live` in its stream stats; we derive it from the
+// block at which the remote endpoint hands off from parallel backprocessing to linear
+// streaming (Response_Session.LinearHandoffBlock): any block at or beyond that height is
+// live tier1 output.
+//
+// This is the condition under which we want --live-drift-reconnect to fire: when we are
+// streaming live but have fallen behind, forcing a reconnect makes the endpoint spin up
+// fresh tier2 parallel backprocessing to close the gap quickly. We deliberately do NOT
+// use the `isLive` flag from the sink's DeltaLivenessChecker, which only latches once a
+// block lands within --live-block-time-delta of wall-clock and so never arms while the
+// stream is perpetually lagging — exactly the case we need to recover from.
+//
+// During a reconnect's catch-up the handoff block sits near the (new) head, so the
+// replayed backprocessed blocks fall below it and we will not reconnect-loop. The
+// handoff > 0 guard skips the brief window before the session has been initialized.
+func (s *SQLSinker) runningFromTier1(blockNum uint64) bool {
+	handoff := s.LinearHandoffBlock()
+	return handoff > 0 && blockNum >= handoff
 }
 
 func (s *SQLSinker) batchBlockModulo(isLive *bool) uint64 {


### PR DESCRIPTION
## Problem

`--live-drift-reconnect` gated the drift check on the sink library's `DeltaLivenessChecker` `isLive` flag, which only latches once a block lands within `--live-block-time-delta` of wall-clock. An endpoint that is perpetually lagging — or stalls before ever reaching the live edge — never arms the trigger, so the sink drifts indefinitely without reconnecting (observed: `live:true`, `drift` well past the configured 15m, no reconnect).

Note the `live:true` in the stream-stats log comes from `runningFromTier1`, which is a *different* signal than the `isLive` flag that gated the check — hence the confusion.

## Fix

Gate the reconnect on whether we're in the live (tier1) linear-streaming segment, detected via the per-session `LinearHandoffBlock` (from the `Response_Session` protobuf), newly exposed by `substreams-sink-go` `v0.5.11`:

- a processed block `>= LinearHandoffBlock` is live tier1 output → arm the drift check;
- blocks below it are replayed from tier2 backprocessing → don't reconnect.

This fires precisely when streaming live and behind (triggering a reconnect → fresh tier2 parallel backfill to close the gap), and avoids reconnect loops during the initial backfill or a reconnect's own catch-up, because the `Session` message refreshes the handoff (≈ new head) before any data flows — so replayed blocks fall below it. Using the session protobuf rather than the `ProgressMessageLastContiguousBlock` Prometheus gauge also avoids stale-across-reconnect state.

## Behavior change

The flag default is flipped from `1h` to empty/disabled (**opt-in**). An unsupplied `--live-drift-reconnect` now performs no automatic reconnect — same as before the feature. Enable with e.g. `--live-drift-reconnect=15m`.

## Dependency

Requires `substreams-sink-go` `v0.5.11` (replace bumped, `go.sum` updated). That release adds `Sinker.LinearHandoffBlock()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)