### PR TITLE
Log running_from_tier1 in postgres sink stats

### DIFF
--- a/sinker/sinker.go
+++ b/sinker/sinker.go
@@ -197,6 +197,7 @@ func (s *SQLSinker) HandleBlockScopedData(ctx context.Context, data *pbsubstream
 
 		s.stats.RecordBlock(cursor.Block())
 		s.stats.RecordBlockTime(data.Clock.GetTimestamp().AsTime())
+		s.stats.RecordRunningFromTier1(s.runningFromTier1(data.Clock.Number))
 		s.stats.RecordFlush(flushDuration)
 		s.lastAppliedBlockNum = &data.Clock.Number
 	}

--- a/sinker/stats.go
+++ b/sinker/stats.go
@@ -19,6 +19,7 @@ type Stats struct {
 	dbFlushedRowsRate  *dmetrics.AvgRatePromCounter
 	lastBlock          bstream.BlockRef
 	lastBlockTime      time.Time
+	runningFromTier1   bool
 	logger             *zap.Logger
 
 	bufferedRows  int
@@ -42,6 +43,10 @@ func NewStats(logger *zap.Logger) *Stats {
 
 func (s *Stats) RecordBlock(block bstream.BlockRef) {
 	s.lastBlock = block
+}
+
+func (s *Stats) RecordRunningFromTier1(v bool) {
+	s.runningFromTier1 = v
 }
 
 func (s *Stats) RecordBlockTime(t time.Time) {
@@ -93,6 +98,7 @@ func (s *Stats) LogNow() {
 		zap.Int("buffered_rows", s.bufferedRows),
 		zap.Duration("time_since_last_flush", time.Since(s.lastFlushTime)),
 		zap.Stringer("last_block", s.lastBlock),
+		zap.Bool("running_from_tier1", s.runningFromTier1),
 	}
 	if !s.lastBlockTime.IsZero() {
 		fields = append(fields, zap.Duration("drift", time.Since(s.lastBlockTime)))


### PR DESCRIPTION
Adds a `running_from_tier1` boolean to the `postgres sink stats` log line.

It reports whether the block being flushed is live (tier1) linear output (`block >= LinearHandoffBlock`) versus replayed from tier2 backprocessing — the same condition that arms `--live-drift-reconnect`. Logging it makes it directly observable whether the drift-reconnect trigger is active for the blocks currently being processed (complements the library's `live` field in the `substreams stream stats` line).

Recorded on flush alongside the existing `RecordBlock`/`RecordBlockTime` calls; no behavior change.

Example:
```
"message":"postgres sink stats", ... "last_block":"#471536636 (...)","running_from_tier1":true
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)