### PR TITLE
fix(clickhouse): coerce int64 to time.Time for Nullable(DateTime) columns

### DIFF
--- a/db/dialect_clickhouse.go
+++ b/db/dialect_clickhouse.go
@@ -449,6 +449,19 @@ func convertToType(value string, valueType reflect.Type) (any, error) {
 			return nil, fmt.Errorf("invalid pointer type: %w", err)
 		}
 
+		// When the pointed-to type is time.Time (i.e. the column is Nullable(DateTime) /
+		// Nullable(Date)), the recursive convertToType returns an int64 (seconds since
+		// epoch) — that's the shape the non-nullable DateTime path relies on for
+		// clickhouse-go to coerce. But for the Ptr/Nullable case we go through reflect.Set
+		// below, which requires the source kind to match the target kind. int64 → time.Time
+		// is not assignable and panics. Convert here so the reflect.Set succeeds and the
+		// driver receives a *time.Time pointer for the Nullable column.
+		if elemType == reflectTypeTime {
+			if seconds, ok := val.(int64); ok {
+				val = time.Unix(seconds, 0).UTC()
+			}
+		}
+
 		// We cannot just return &val here as this will return an *interface{} that the Clickhouse Go client won't be
 		// able to convert on inserting. Instead, we create a new variable using the type that valueType has been
 		// pointing to, assign the converted value from convertToType to that and then return a pointer to the new variable.

--- a/db/dialect_clickhouse_test.go
+++ b/db/dialect_clickhouse_test.go
@@ -349,6 +349,18 @@ func Test_convertToType(t *testing.T) {
 			expect:    nil,
 			expectErr: errors.New(`"Time" is not supported as Clickhouse Array type`),
 			valueType: reflect.TypeOf([]time.Time{}),
+		}, {
+			name:      "Nullable DateTime from integer seconds",
+			value:     "1609459200",
+			expect:    func() any { t := time.Unix(1609459200, 0).UTC(); return &t }(),
+			expectErr: nil,
+			valueType: reflect.TypeOf((*time.Time)(nil)),
+		}, {
+			name:      "Nullable DateTime from ISO 8601",
+			value:     "2021-01-01T00:00:00Z",
+			expect:    func() any { t := time.Unix(1609459200, 0).UTC(); return &t }(),
+			expectErr: nil,
+			valueType: reflect.TypeOf((*time.Time)(nil)),
 		},
 	}
 	for _, test := range tests {


### PR DESCRIPTION
## Summary

`convertToType` in `db/dialect_clickhouse.go` panics with `reflect.Set: value of type int64 is not assignable to type time.Time` when a sink schema declares a column as `Nullable(DateTime)` / `Nullable(Date)`. Plain (non-nullable) DateTime columns work because the int64 reaches `clickhouse-go`'s prepared-batch path, which coerces it internally. The nullable path goes through `reflect.Set` on a freshly allocated `time.Time` field, which is strict about kind compatibility.

Patch converts `int64` → `time.Time` (`time.Unix(seconds, 0).UTC()`) when the inner element type is `time.Time`, so `reflect.Set` receives a kind-compatible value. The driver accepts `*time.Time` for nullable columns.

## Why

The bug is silent on schemas without `Nullable(DateTime)` (hypercore, polymarket evm, evm-tokens), so it hasn't surfaced in production. It triggers on schemas that legitimately want a NULL placeholder for an event timestamp that may not be set yet — e.g. a `markets.close_time` that's NULL for live markets, populated at resolution. Without the fix, the entire flush batch panics and no rows land.

## Code references

- `db/dialect_clickhouse.go` — `convertToType` `reflect.Ptr` branch (added kind-coercion before `reflect.Set`).
- `db/dialect_clickhouse_test.go` — two test cases for `Nullable(DateTime)` via integer seconds and ISO 8601.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)